### PR TITLE
Add new features to Updater app

### DIFF
--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -21,4 +21,18 @@
         <item>3</item>
         <item>2</item>
     </string-array>
+
+    <string-array name="update_interval_entries" translatable="false">
+        <item>@string/update_interval_never</item>
+        <item>@string/update_interval_4hour</item>
+        <item>@string/update_interval_1day</item>
+        <item>@string/update_interval_1week</item>
+    </string-array>
+
+    <string-array name="update_interval_values" translatable="false">
+        <item>-1</item>
+        <item>14400000</item>
+        <item>86400000</item>
+        <item>604800000</item>
+    </string-array>	
 </resources>

--- a/res/values/config.xml
+++ b/res/values/config.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="url" translatable="false">s3bucket</string>
+    <string name="update_url_default" translatable="false">s3bucket</string>
+    <string name="update_interval_default">14400000</string>
     <string name="channel_default" translatable="false">stable</string>
     <string name="network_type_default" translatable="false">1</string>
     <string name="battery_not_low_default" translatable="false">false</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -11,6 +11,10 @@
     <string name="notification_text_legacy">Please install the latest OS release.</string>
     <string name="notification_reboot_action">Reboot</string>
     <string name="notification_reboot_action_legacy">Reboot and install</string>
+    <string name="notification_update_fail">Update Error</string>
+    <string name="notification_update_fail_title">Error updating OS</string>
+    <string name="notification_update_fail_text">Please check your settings.</string>
+    <string name="notification_update_fail_details">Error details</string>
     <string name="settings_title">System update settings</string>
     <string name="channel_title">Release channel</string>
     <string name="channel_stable">Stable</string>
@@ -25,4 +29,10 @@
     <string name="idle_reboot_summary">Automatically reboot once the device is idle after successfully installing an update</string>
     <string name="check_for_updates_title">Check for updates</string>
     <string name="check_for_updates_summary">Tap to check for updates as soon as possible</string>
+    <string name="update_url_title">Update server URL</string>
+    <string name="update_interval_title">Update check interval</string>
+    <string name="update_interval_never">Never</string>
+    <string name="update_interval_4hour">4 hours</string>
+    <string name="update_interval_1day">1 day</string>
+    <string name="update_interval_1week">1 week</string>
 </resources>

--- a/res/xml/settings.xml
+++ b/res/xml/settings.xml
@@ -8,6 +8,13 @@
             android:title="@string/check_for_updates_title"
             android:summary="@string/check_for_updates_summary" />
 
+    <ListPreference android:key="update_interval"
+            android:title="@string/update_interval_title"
+            android:summary="%s"
+            android:entries="@array/update_interval_entries"
+            android:entryValues="@array/update_interval_values"
+            android:defaultValue="@string/update_interval_default" />
+
     <ListPreference android:key="channel"
             android:title="@string/channel_title"
             android:summary="%s"
@@ -32,5 +39,11 @@
             android:title="@string/idle_reboot_title"
             android:summary="@string/idle_reboot_summary"
             android:defaultValue="@string/idle_reboot_default" />
+			
+    <EditTextPreference android:key="update_url"
+            android:enabled="false"
+            android:title="@string/update_url_title"
+            android:summary="@string/update_url_default"
+            android:defaultValue="@string/update_url_default" />
 
 </PreferenceScreen>

--- a/src/app/seamlessupdate/client/BootReceiver.java
+++ b/src/app/seamlessupdate/client/BootReceiver.java
@@ -11,7 +11,9 @@ public class BootReceiver extends BroadcastReceiver {
     public void onReceive(final Context context, final Intent intent) {
         if (context.getSystemService(UserManager.class).isSystemUser()) {
             Settings.getPreferences(context).edit().putBoolean(Settings.KEY_WAITING_FOR_REBOOT, false).apply();
-            PeriodicJob.schedule(context);
+            if (Settings.getUpdateInterval(context) > 0) {
+                PeriodicJob.schedule(context);
+            }
         } else {
             context.getPackageManager().setApplicationEnabledSetting(context.getPackageName(),
                 PackageManager.COMPONENT_ENABLED_STATE_DISABLED, 0);

--- a/src/app/seamlessupdate/client/NotificationHandler.java
+++ b/src/app/seamlessupdate/client/NotificationHandler.java
@@ -15,8 +15,10 @@ public class NotificationHandler {
     private static final int NOTIFICATION_ID_DOWNLOAD = 1;
     private static final int NOTIFICATION_ID_INSTALL = 2;
     private static final int NOTIFICATION_ID_REBOOT = 3;
+    private static final int NOTIFICATION_ID_ERROR = 4;
     private static final String NOTIFICATION_CHANNEL_ID = "updates2";
     private static final String NOTIFICATION_CHANNEL_ID_PROGRESS = "progress";
+    private static final String NOTIFICATION_CHANNEL_ID_ERROR = "update_error";
     private static final int PENDING_REBOOT_ID = 1;
     private static final int PENDING_SETTINGS_ID = 2;
 
@@ -79,6 +81,28 @@ public class NotificationHandler {
 
     void cancelInstallNotification() {
         notificationManager.cancel(NOTIFICATION_ID_INSTALL);
+    }
+	
+    void showUpdateFailNotification(String errorText) {
+        String title = context.getString(R.string.notification_update_fail_title);
+        String text = context.getString(R.string.notification_update_fail_text);
+        String details = context.getString(R.string.notification_update_fail_details);
+        String expandedText = text.concat("\n").concat(details).concat(": ").concat(errorText);
+
+        final NotificationChannel channel = new NotificationChannel(NOTIFICATION_CHANNEL_ID_ERROR,
+                context.getString(R.string.notification_update_fail), NotificationManager.IMPORTANCE_HIGH);
+        channel.enableLights(true);
+        channel.enableVibration(true);
+        notificationManager.createNotificationChannel(channel);
+
+        notificationManager.notify(NOTIFICATION_ID_ERROR, new Notification.Builder(context, NOTIFICATION_CHANNEL_ID_ERROR)
+                .setContentIntent(getPendingSettingsIntent())
+                .setContentTitle(title)
+                .setContentText(text)
+                .setSmallIcon(R.drawable.ic_system_update_white_24dp)
+                .setStyle(new Notification.BigTextStyle()
+                        .bigText(expandedText))
+                .build());
     }
 
     private void createProgressNotificationChannel() {

--- a/src/app/seamlessupdate/client/PeriodicJob.java
+++ b/src/app/seamlessupdate/client/PeriodicJob.java
@@ -17,12 +17,14 @@ public class PeriodicJob extends JobService {
     private static final String TAG = "PeriodicJob";
     private static final int JOB_ID_PERIODIC = 1;
     private static final int JOB_ID_RETRY = 2;
-    private static final long INTERVAL_MILLIS = 4 * 60 * 60 * 1000;
     private static final long MIN_LATENCY_MILLIS = 4 * 60 * 1000;
     private static final String EXTRA_JOB_CHANNEL = "extra_job_channel";
+    private static final String EXTRA_JOB_URL = "extra_job_url";
 
     static void schedule(final Context context, final boolean force) {
         final String channel = SystemProperties.get("sys.update.channel", Settings.getChannel(context));
+        final String url = Settings.getUpdateURL(context);
+        final long updateInterval = Settings.getUpdateInterval(context);
         final int networkType = Settings.getNetworkType(context);
         final boolean batteryNotLow = Settings.getBatteryNotLow(context);
         final JobScheduler scheduler = context.getSystemService(JobScheduler.class);
@@ -31,19 +33,21 @@ public class PeriodicJob extends JobService {
                 jobInfo.getNetworkType() == networkType &&
                 jobInfo.isRequireBatteryNotLow() == batteryNotLow &&
                 jobInfo.isPersisted() &&
-                jobInfo.getIntervalMillis() == INTERVAL_MILLIS &&
-                Objects.equals(jobInfo.getExtras().getString(EXTRA_JOB_CHANNEL), channel)) {
+                jobInfo.getIntervalMillis() == updateInterval &&
+                Objects.equals(jobInfo.getExtras().getString(EXTRA_JOB_CHANNEL), channel) &&
+                Objects.equals(jobInfo.getExtras().getString(EXTRA_JOB_URL), url)) {
             Log.d(TAG, "Periodic job already registered");
             return;
         }
         final PersistableBundle extras = new PersistableBundle();
         extras.putString(EXTRA_JOB_CHANNEL, channel);
+        extras.putString(EXTRA_JOB_URL, url);
         final ComponentName serviceName = new ComponentName(context, PeriodicJob.class);
         final int result = scheduler.schedule(new JobInfo.Builder(JOB_ID_PERIODIC, serviceName)
             .setRequiredNetworkType(networkType)
             .setRequiresBatteryNotLow(batteryNotLow)
             .setPersisted(true)
-            .setPeriodic(INTERVAL_MILLIS)
+            .setPeriodic((updateInterval > 0) ? updateInterval : 14400001)
             .setExtras(extras)
             .build());
         if (result == JobScheduler.RESULT_FAILURE) {


### PR DESCRIPTION
Adds three new features:
1. Ability to change the update URL. This setting is disabled by default. If someone wants to use this, all they would have to do would be to use something like `sed` to change settings.xml. I think this would be useful if someone is building and deploying updates with their own server or VPS, or wants to redeploy with a new stack name, and avoid sideloading.
2. Ability to change the update check frequency, including disabling updates. 
3. Notifications for failed updates. Inspired by https://github.com/dan-v/rattlesnakeos-stack/issues/144. If an update fails, a notification is sent. It includes a few details about the error via `Exception.getMessage()`. Tailored error messages would be better, but the problem is that the entire update code is wrapped in a big try block, so customizing error messages would require changing the code significantly. I do think that having error messages is important, though, because if an update fails, it will retry every 4 minutes for eternity. For example, if you set the channel to `beta`, this doesn't stop updates but actually causes them fail, so it will keep retrying. To stop these retries, updates, set the update frequency to `Never`.

Let me know if you have any questions on this or want me to change anything. I've tested it out and everything works fine, but more testing is always good.